### PR TITLE
fix: getLastPathSegment broken on some devices.

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -47,6 +47,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.List;
+import java.util.UUID;
 
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.react.modules.core.PermissionAwareActivity;
@@ -68,6 +69,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   private final ReactApplicationContext reactContext;
   private final int dialogThemeId;
+
+  public static String fileNamePrefix = "exodus_image_picker_temp_";
 
   protected Callback callback;
   private ReadableMap options;
@@ -643,7 +646,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
    * @throws Exception
    */
   private File createFileFromURI(Uri uri) throws Exception {
-    File file = new File(reactContext.getExternalCacheDir(), "photo-" + uri.getLastPathSegment() + "." + getFileTypeFromMime(uri));
+    String filename = fileNamePrefix  + UUID.randomUUID() + "." + getFileTypeFromMime(uri);
+    File fileDir = reactContext.getCacheDir();
+    File file = new File(fileDir, filename);
     InputStream input = reactContext.getContentResolver().openInputStream(uri);
     OutputStream output = new FileOutputStream(file);
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -311,6 +311,8 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   @ReactMethod
   public void launchImageLibrary(final ReadableMap options, final Callback callback)
   {
+    if (this.callback != null) return;
+
     final Activity currentActivity = getCurrentActivity();
     if (currentActivity == null) {
       responseHelper.invokeError(callback, "can't find current Activity");

--- a/android/src/main/java/com/imagepicker/ResponseHelper.java
+++ b/android/src/main/java/com/imagepicker/ResponseHelper.java
@@ -73,6 +73,7 @@ public class ResponseHelper
 
     public void invokeResponse(@NonNull final Callback callback)
     {
-        callback.invoke(response);
+        if(callback != null)
+            callback.invoke(response);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exodus/react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.28.1-exodus.6",
+  "version": "0.28.1-exodus.7",
   "main": "index.js",
   "homepage": "https://github.com/react-community/react-native-image-picker",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exodus/react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.28.1-exodus.7",
+  "version": "0.28.1-exodus.8",
   "main": "index.js",
   "homepage": "https://github.com/react-community/react-native-image-picker",
   "repository": {


### PR DESCRIPTION
uri.getLastPathSegment() returns broken data on  some devices (Xiaomi in my case). We don't really need to preseve original image name anyway so we generate one. This fixes broken image picker on some devices
