### PR TITLE
fix: process activity result that are relevant

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -357,6 +357,11 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   @Override
   public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+
+    if (!isValidRequestCode(requestCode)) {
+      return;
+    }
+
     responseHelper.cleanResponse();
 
     // user cancel
@@ -616,6 +621,16 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   private boolean isCameraAvailable() {
     return reactContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA)
       || reactContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
+  }
+
+  private boolean isValidRequestCode(int requestCode) {
+    switch (requestCode) {
+      case REQUEST_LAUNCH_IMAGE_CAPTURE:
+      case REQUEST_LAUNCH_IMAGE_LIBRARY:
+      case REQUEST_LAUNCH_VIDEO_LIBRARY:
+      case REQUEST_LAUNCH_VIDEO_CAPTURE: return true;
+      default: return false;
+    }
   }
 
   private @NonNull String getRealPathFromURI(@NonNull final Uri uri) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Verifying seedless backup flow on Android, we found a crash when the user taps on the backup verification link. Error stack trace indicates that `NullPointerException` error occurs on `getAbsolutePath()` on [this line](https://github.com/ExodusMovement/react-native-image-picker/blob/exodus/android/src/main/java/com/imagepicker/utils/MediaUtils.java#L247:L247). The `[onActivityResult()](https://github.com/ExodusMovement/react-native-image-picker/blob/exodus/android/src/main/java/com/imagepicker/ImagePickerModule.java#L359)` was triggered although user didn't interact with any image picker features. 

The solution written here was inspired by [a PR from upstream](https://github.com/react-native-image-picker/react-native-image-picker/pull/1464). We stop further execution on onActivityResult() if the request code is invalid.

See the following screencast for details: https://www.loom.com/share/3080911fd3cd46f5b9dabed248d55797

closes: https://app.asana.com/0/1202170937152401/1203667658145392/f

## Test Plan (required)

### Setup

(simulate deep link click via adb shell won't reproduce crash, hence need to run seedless backup workflow)

- Use Android emulator with API 13.0 with Google Play
- Ensure emulator has Google Play Service 
- Login to your Google account on android emulator
- Setup and run seedless server locally, see https://github.com/ExodusMovement/seedless for instructions
- on exodus-mobile, apply the following diff:

```
diff --git a/src/_local_modules/seedless/selectors/is-ready.js b/src/_local_modules/seedless/selectors/is-ready.js
index 03a36a5dc..7fdd851c2 100644
--- a/src/_local_modules/seedless/selectors/is-ready.js
+++ b/src/_local_modules/seedless/selectors/is-ready.js
@@ -1,5 +1,5 @@
 import { get } from 'lodash'
 
-const isReadySelector = (state) => get(state, 'seedless.loaded') || false
+const isReadySelector = (state) => true // get(state, 'seedless.loaded') || false
 
 export default isReadySelector
```

```
diff --git a/src/constants/seedless.js b/src/constants/seedless.js
index e528d0aa2..6649e5b49 100644
--- a/src/constants/seedless.js
+++ b/src/constants/seedless.js
@@ -4,7 +4,7 @@ import { enableSeedlessLocalTimelockServer, isIos, enablePrivateFeatures } from
 export { enableSeedless } from '~/constants/env'
 
 const TIMELOCK_SERVER_DEV_URL = enableSeedlessLocalTimelockServer
-  ? `http://${getPackagerHost()}:5330/api`   
+  ? `http://10.0.2.2:5330/api`    // connect to local server correctly
   : 'https://watermelon-d.exodus.io/api'
 
 const TIMELOCK_SERVER_PROD_URL = 'https://watermelon-p.exodus.io/api'
```

- ensure local seedless server is running
- run command on exodus-mobile:

```
ENABLE_SEEDLESS=true LOCAL_SEEDLESS_SERVER=true yarn metro
yarn android:genesis
```

_to reproduce crash_ => install react-native-image-picker of "exodus" branch locally on exodus-mobile
_to resolve crash_ => install react-native-image-picker of "nafis/filter-request-code" branch locally on exodus-mobile

### Resolve crash

Given the user open Profile > Security > Backup > Keyless Backup
and they enter google email
and they tap create keyless backup button
and app shows Check Your Email page
When they receive email containing the backup verification link
and they tap the link

_expected_: Then app able to complete the backup process
_actual_: Then app crash