### PR TITLE
chore: bump version to 0.28.1-exodus.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@exodus/react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.28.1-exodus.9",
+  "version": "0.28.1-exodus.10",
   "main": "index.js",
   "homepage": "https://github.com/react-community/react-native-image-picker",
   "repository": {


### PR DESCRIPTION
bump version to 0.28.1-exodus.10

note: new line at the end of file is coming from pre-commit hooks